### PR TITLE
Include typescript files in the project parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,0 @@
-# Fork ofsonar-visual-studio
-
-Exists to make a smnall change to include support for typescript files - useful where the generated js files are not included in the csproj file

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Fork ofsonar-visual-studio
+
+Exists to make a smnall change to include support for typescript files - useful where the generated js files are not included in the csproj file

--- a/src/main/java/org/sonar/plugins/visualstudio/VisualStudioProjectParser.java
+++ b/src/main/java/org/sonar/plugins/visualstudio/VisualStudioProjectParser.java
@@ -47,7 +47,7 @@ public class VisualStudioProjectParser {
 
   private static class Parser {
 
-    private static final Set<String> PROJECT_ITEM_TYPES = ImmutableSet.of("Compile", "Content", "EmbeddedResource", "None", "ClCompile", "Page");
+    private static final Set<String> PROJECT_ITEM_TYPES = ImmutableSet.of("Compile", "Content", "EmbeddedResource", "None", "ClCompile", "Page", "TypeScriptCompile");
 
     private File file;
     private XMLStreamReader stream;


### PR DESCRIPTION
There is work underway to provide a [typescript plugin](https://github.com/Pablissimo/SonarTsPlugin) for sonarqube but in order for this to work in conjunction with the vs bootstrapper the bootstrapper needs to include ts files in the list of files its interested in.
This change simply adds the ```TypeScriptCompile``` element to the list in the parser
I appreciate that there maybe plans in the future to make adding file types easier but this small change will allow the ts plugin to be adopted more easily in the short term 